### PR TITLE
fix(word generator): error JSON schema invalid when using Claude model

### DIFF
--- a/src/routes/wordGenerator/wordGeneratorModel.ts
+++ b/src/routes/wordGenerator/wordGeneratorModel.ts
@@ -45,22 +45,22 @@ const ContentSchema = z.object({
 });
 
 // Define the base schema for a section
-const BaseSectionSchema = z.object({
+const SectionSchema = z.object({
+  sectionId: z.string().openapi({
+    description: 'A unique identifier for the section.',
+  }),
   heading: z.string().optional().openapi({
     description: 'Heading of the section.',
   }),
   headingLevel: z.number().int().min(1).optional().openapi({
     description: 'Level of the heading (e.g., 1 for main heading, 2 for subheading).',
   }),
+  parentSectionId: z.string().optional().openapi({
+    description:
+      'The unique identifier of the parent section, if this section is a child of another. Leave empty if this section has no parent.',
+  }),
   content: z.array(ContentSchema).optional().openapi({
     description: 'Content contained within the section, including paragraphs, tables, etc.',
-  }),
-});
-
-// Extend the base schema with subSections
-const SectionSchema = BaseSectionSchema.extend({
-  subSections: z.array(BaseSectionSchema).optional().openapi({
-    description: 'Subsections within the main section.',
   }),
 });
 


### PR DESCRIPTION
Bug Report: 
![claude_error](https://github.com/user-attachments/assets/8cbf35ef-0841-412b-83c3-372590108159)

RCA:
- The issue is caused by the JSON validator which did not allow using $ref in the function calling definition for recursive object (subsection)
![image](https://github.com/user-attachments/assets/0491bf60-d319-415c-bbbd-a0992ca8ade0)

Changes: 
- Update input params by removing subsection property
- Add sectionId and parentSectionId to sections object.
- Add function to construct section hierarchy.

Demo:
https://www.loom.com/share/d97d2972094542ba9e00374ef583dc09?sid=c14ebc8b-bc38-4062-acab-46c590123d12

Note: 
Reference the changes in TypingMind Plugin:
https://github.com/TypingMind/plugin-word-generator/commit/4175a5fcba742a204d1e4ad6875f22a4eb996516
