### PR TITLE
Allow mounting server at a sub-path like /path/to/plugins

### DIFF
--- a/src/api-docs/openAPIRouter.ts
+++ b/src/api-docs/openAPIRouter.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response, Router } from 'express';
 import swaggerUi from 'swagger-ui-express';
+import { env } from '@/common/utils/envConfig';
 
 import { generateOpenAPIDocument } from '@/api-docs/openAPIDocumentGenerator';
 
@@ -12,7 +13,7 @@ export const openAPIRouter: Router = (() => {
     res.send(openAPIDocument);
   });
 
-  router.use('/', swaggerUi.serve, swaggerUi.setup(openAPIDocument));
+  router.use(env.MOUNT_PATH + '/', swaggerUi.serve, swaggerUi.setup(openAPIDocument));
 
   return router;
 })();

--- a/src/common/utils/envConfig.ts
+++ b/src/common/utils/envConfig.ts
@@ -8,6 +8,7 @@ export const env = cleanEnv(process.env, {
   HOST: host({ default: 'localhost' }),
   PORT: port({ default: 3000 }),
   CORS_ORIGIN: str({ default: '*' }),
+  MOUNT_PATH: str({ default: '' }),
   COMMON_RATE_LIMIT_MAX_REQUESTS: num({ default: 100 }),
   COMMON_RATE_LIMIT_WINDOW_MS: num({ default: 60000 }),
 });

--- a/src/routes/excelGenerator/excelGeneratorRouter.ts
+++ b/src/routes/excelGenerator/excelGeneratorRouter.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import cron from 'node-cron';
 import path from 'path';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiRequestBody } from '@/api-docs/openAPIRequestBuilders';
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
@@ -17,7 +18,7 @@ export const excelGeneratorRegistry = new OpenAPIRegistry();
 excelGeneratorRegistry.register('ExcelGenerator', ExcelGeneratorResponseSchema);
 excelGeneratorRegistry.registerPath({
   method: 'post',
-  path: '/excel-generator/generate',
+  path: env.MOUNT_PATH + '/excel-generator/generate',
   tags: ['Excel Generator'],
   request: {
     body: createApiRequestBody(ExcelGeneratorRequestBodySchema, 'application/json'),

--- a/src/routes/healthCheck/healthCheckRouter.ts
+++ b/src/routes/healthCheck/healthCheckRouter.ts
@@ -2,6 +2,7 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import express, { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
 import { ResponseStatus, ServiceResponse } from '@/common/models/serviceResponse';
@@ -14,7 +15,7 @@ export const healthCheckRouter: Router = (() => {
 
   healthCheckRegistry.registerPath({
     method: 'get',
-    path: '/health-check',
+    path: env.MOUNT_PATH + '/health-check',
     tags: ['Health Check'],
     responses: createApiResponse(z.null(), 'Success'),
   });

--- a/src/routes/notionDatabase/notionDatabaseRouter.ts
+++ b/src/routes/notionDatabase/notionDatabaseRouter.ts
@@ -2,6 +2,7 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import { Client as NotionClient } from '@notionhq/client';
 import express, { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiRequestBody } from '@/api-docs/openAPIRequestBuilders';
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
@@ -34,7 +35,7 @@ export const notionDatabaseRegistry = new OpenAPIRegistry();
 notionDatabaseRegistry.register('Notion Database', NotionDatabaseStructureViewerResponseSchema);
 notionDatabaseRegistry.registerPath({
   method: 'post',
-  path: '/notion-database/view-structure',
+  path: env.MOUNT_PATH + '/notion-database/view-structure',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseStructureViewerRequestBodySchema, 'application/json'),
@@ -44,7 +45,7 @@ notionDatabaseRegistry.registerPath({
 
 notionDatabaseRegistry.registerPath({
   method: 'post',
-  path: '/notion-database/create-page',
+  path: env.MOUNT_PATH + '/notion-database/create-page',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseCreatePageRequestBodySchema, 'application/json'),
@@ -54,7 +55,7 @@ notionDatabaseRegistry.registerPath({
 
 notionDatabaseRegistry.registerPath({
   method: 'patch',
-  path: '/notion-database/update-page',
+  path: env.MOUNT_PATH + '/notion-database/update-page',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseUpdatePageRequestBodySchema, 'application/json'),
@@ -64,7 +65,7 @@ notionDatabaseRegistry.registerPath({
 
 notionDatabaseRegistry.registerPath({
   method: 'patch',
-  path: '/notion-database/archive-page',
+  path: env.MOUNT_PATH + '/notion-database/archive-page',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseArchivePageRequestBodySchema, 'application/json'),
@@ -74,7 +75,7 @@ notionDatabaseRegistry.registerPath({
 
 notionDatabaseRegistry.registerPath({
   method: 'post',
-  path: '/notion-database/query-pages',
+  path: env.MOUNT_PATH + '/notion-database/query-pages',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseQueryPageRequestBodySchema, 'application/json'),
@@ -84,7 +85,7 @@ notionDatabaseRegistry.registerPath({
 
 notionDatabaseRegistry.registerPath({
   method: 'post',
-  path: '/notion-database/create-database',
+  path: env.MOUNT_PATH + '/notion-database/create-database',
   tags: ['Notion Database'],
   request: {
     body: createApiRequestBody(NotionDatabaseMakerRequestBodySchema, 'application/json'),

--- a/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
+++ b/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes';
 import cron from 'node-cron';
 import path from 'path';
 import pptxgen from 'pptxgenjs';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiRequestBody } from '@/api-docs/openAPIRequestBuilders';
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
@@ -19,7 +20,7 @@ export const powerpointGeneratorRegistry = new OpenAPIRegistry();
 powerpointGeneratorRegistry.register('PowerpointGenerator', PowerpointGeneratorResponseSchema);
 powerpointGeneratorRegistry.registerPath({
   method: 'post',
-  path: '/powerpoint-generator/generate',
+  path: env.MOUNT_PATH + '/powerpoint-generator/generate',
   tags: ['Powerpoint Generator'],
   request: {
     body: createApiRequestBody(PowerpointGeneratorRequestBodySchema, 'application/json'),

--- a/src/routes/webPageReader/webPageReaderRouter.ts
+++ b/src/routes/webPageReader/webPageReaderRouter.ts
@@ -5,6 +5,7 @@ import express, { Request, Response, Router } from 'express';
 import got from 'got';
 import { StatusCodes } from 'http-status-codes';
 import { JSDOM } from 'jsdom';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
 import { ResponseStatus, ServiceResponse } from '@/common/models/serviceResponse';
@@ -64,7 +65,7 @@ export const webPageReaderRouter: Router = (() => {
 
   articleReaderRegistry.registerPath({
     method: 'get',
-    path: '/web-page-reader/get-content',
+    path: env.MOUNT_PATH + '/web-page-reader/get-content',
     tags: ['Web Page Reader'],
     request: {
       query: WebPageReaderRequestParamSchema,

--- a/src/routes/wordGenerator/wordGeneratorRouter.ts
+++ b/src/routes/wordGenerator/wordGeneratorRouter.ts
@@ -24,6 +24,7 @@ import fs from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import cron from 'node-cron';
 import path from 'path';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiRequestBody } from '@/api-docs/openAPIRequestBuilders';
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
@@ -36,7 +37,7 @@ export const wordGeneratorRegistry = new OpenAPIRegistry();
 wordGeneratorRegistry.register('WordGenerator', WordGeneratorResponseSchema);
 wordGeneratorRegistry.registerPath({
   method: 'post',
-  path: '/word-generator/generate',
+  path: env.MOUNT_PATH + '/word-generator/generate',
   tags: ['Word Generator'],
   request: {
     body: createApiRequestBody(WordGeneratorRequestBodySchema, 'application/json'),

--- a/src/routes/youtubeTranscript/youtubeTranscriptRouter.ts
+++ b/src/routes/youtubeTranscript/youtubeTranscriptRouter.ts
@@ -2,6 +2,7 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import express, { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { YoutubeTranscript } from 'youtube-transcript';
+import { env } from '@/common/utils/envConfig';
 
 import { createApiResponse } from '@/api-docs/openAPIResponseBuilders';
 import { ResponseStatus, ServiceResponse } from '@/common/models/serviceResponse';
@@ -17,7 +18,7 @@ export const youtubeTranscriptRouter: Router = (() => {
 
   youtubeTranscriptRegistry.registerPath({
     method: 'get',
-    path: '/youtube-transcript/get-transcript',
+    path: env.MOUNT_PATH + '/youtube-transcript/get-transcript',
     tags: ['Youtube Transcript'],
     request: {
       query: YoutubeTranscriptRequestParamSchema,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import express, { Express } from 'express';
 import helmet from 'helmet';
 import { pino } from 'pino';
+import { env } from '@/common/utils/envConfig';
 
 import { openAPIRouter } from '@/api-docs/openAPIRouter';
 import errorHandler from '@/common/middleware/errorHandler';
@@ -36,14 +37,14 @@ app.use((req, res, next) => {
 app.use(requestLogger());
 
 // Routes
-app.use('/health-check', healthCheckRouter);
-app.use('/images', express.static('public/images'));
-app.use('/youtube-transcript', youtubeTranscriptRouter);
-app.use('/web-page-reader', webPageReaderRouter);
-app.use('/powerpoint-generator', powerpointGeneratorRouter);
-app.use('/word-generator', wordGeneratorRouter);
-app.use('/excel-generator', excelGeneratorRouter);
-app.use('/notion-database', notionDatabaseRouter);
+app.use(env.MOUNT_PATH + '/health-check', healthCheckRouter);
+app.use(env.MOUNT_PATH + '/images', express.static('public/images'));
+app.use(env.MOUNT_PATH + '/youtube-transcript', youtubeTranscriptRouter);
+app.use(env.MOUNT_PATH + '/web-page-reader', webPageReaderRouter);
+app.use(env.MOUNT_PATH + '/powerpoint-generator', powerpointGeneratorRouter);
+app.use(env.MOUNT_PATH + '/word-generator', wordGeneratorRouter);
+app.use(env.MOUNT_PATH + '/excel-generator', excelGeneratorRouter);
+app.use(env.MOUNT_PATH + '/notion-database', notionDatabaseRouter);
 
 // Swagger UI
 app.use(openAPIRouter);


### PR DESCRIPTION
The plugins-server only seems to work when mounted at the root of a domain; e.g., example.com.

Due to my hosting situation, I needed to mount it at a sub-path, for example:

example.com/path/to/plugins/

This change allows that to happen. To use it, set an environment variable called `MOUNT_PATH`; in my example, you'd set

`MOUNT_PATH=/path/to/plugins`

If you omit this new variable, there will be no change to the behavior, and everything will work as it has before.

Hopefully you don't mind the unsolicited PR out of the blue...I would have asked about it beforehand, but I already had the code changes done, so I figured I'd save a step and just submit it. :)