### PR TITLE
allow container to run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,48 @@
 FROM node:current-slim AS builder
 
+# Define User ID and Group ID which the Server should run under
+# Should be specified on buld, therfor buildargs
 ARG UID=3000
 ARG GID=3000
 
+# Set the WORKDIR
+# also make it simple so it can not be confused with system files
 WORKDIR /app
 
+# copy the whole repo into the container because all
+# required files are stored on the project root
 COPY --chown=$UID:$GID . .
 
-RUN npm ci && npm run build && chown -R $UID:$GID /app
+# run npm install and build as root
+# because npm and node store some files und /root for some reason
+RUN npm ci && npm run build \
+    && chown -R $UID:$GID /app # change permission to the specified UID and GID after finish
 
 FROM node:current-slim AS prod
 
 ARG UID=3000
 ARG GID=3000
 
+# set default env variable for prod
 ENV NODE_ENV="production"
 ENV PORT="8080"
 ENV HOST="0.0.0.0"
 
 WORKDIR /app
 
+# copy the dist folder from the previous stage
 COPY --from=builder --chown=$UID:$GID /app/dist /app/dist
+# we also need the package.json and package-lock.json for the deps
 COPY --from=builder /app/package*.json /app/
 
-RUN npm ci --omit=dev --ignore-scripts && chown -R $UID:$GID /app
+# reinstall all prod dependencies (this also needs to run as root)
+# skip scripts (prepare script) because it uses a dev dependency
+RUN npm ci --omit=dev --ignore-scripts \
+    && chown -R $UID:$GID /app # correct permissions
 
+# Drop user to the defined uid and gid
 USER $UID:$GID
 
+# run server via direct call
+# becuase npm run start requires a dev dependency
 CMD ["dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN npm ci --omit=dev --ignore-scripts \
 # Drop user to the defined uid and gid
 USER $UID:$GID
 
+# define which port will be exposed
+# this can be build with a build argument
+EXPOSE 8080
+
 # run server via direct call
 # becuase npm run start requires a dev dependency
 CMD ["dist/index.js"]

--- a/src/routes/excelGenerator/excelGeneratorRouter.ts
+++ b/src/routes/excelGenerator/excelGeneratorRouter.ts
@@ -26,7 +26,7 @@ excelGeneratorRegistry.registerPath({
 });
 
 // Create folder to contains generated files
-const exportsDir = path.join(__dirname, '../../..', 'excel-exports');
+const exportsDir = '/tmp/excel-exports';
 
 // Ensure the exports directory exists
 if (!fs.existsSync(exportsDir)) {

--- a/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
+++ b/src/routes/powerpointGenerator/powerpointGeneratorRouter.ts
@@ -28,7 +28,7 @@ powerpointGeneratorRegistry.registerPath({
 });
 
 // Create folder to contains generated files
-const exportsDir = path.join(__dirname, '../../..', 'powerpoint-exports');
+const exportsDir = '/tmp/powerpoint-exports';
 // Ensure the exports directory exists
 if (!fs.existsSync(exportsDir)) {
   fs.mkdirSync(exportsDir, { recursive: true });

--- a/src/routes/wordGenerator/wordGeneratorRouter.ts
+++ b/src/routes/wordGenerator/wordGeneratorRouter.ts
@@ -45,7 +45,7 @@ wordGeneratorRegistry.registerPath({
 });
 
 // Create folder to contains generated files
-const exportsDir = path.join(__dirname, '../../..', 'word-exports');
+const exportsDir = '/tmp/word-exports';
 // Ensure the exports directory exists
 if (!fs.existsSync(exportsDir)) {
   fs.mkdirSync(exportsDir, { recursive: true });


### PR DESCRIPTION
This merge request aims to allow the plugin-server to run as non-root. It also tries to reduce the image size and remove unnecessary dependencies.

This Container should no be able to run in a hardened Kubernetes cluster which enforced non-root containers.

## Changes

### Dockerfile

- Use a multistage Build to separate build stage from final prod stage
- exclude dev dependencies from final build
- set some default env variables

### Code 

- change export path of files to tmp folder. Every User can write to the tmp folder.

## Disclaimer

This is not tested for development, but I assume, that development is not done within the container.

I'm also not very familiar with this codebase and therefor no application testing was done except for simple startups.